### PR TITLE
nga_parallaxMotionEffectGroup getter responsible for instantiation

### DIFF
--- a/Classes/NGAParallaxMotion.m
+++ b/Classes/NGAParallaxMotion.m
@@ -38,12 +38,7 @@ static void * const kNGAParallaxMotionEffectGroupKey = (void*)&kNGAParallaxMotio
     }
 
     UIMotionEffectGroup * parallaxGroup = [self nga_parallaxMotionEffectGroup];
-    if (!parallaxGroup)
-    {
-        parallaxGroup = [[UIMotionEffectGroup alloc] init];
-        [self nga_setParallaxMotionEffectGroup:parallaxGroup];
-        [self addMotionEffect:parallaxGroup];
-    }
+    [self addMotionEffect:parallaxGroup];
     
     UIInterpolatingMotionEffect *xAxis = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
     UIInterpolatingMotionEffect *yAxis = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
@@ -67,12 +62,18 @@ static void * const kNGAParallaxMotionEffectGroupKey = (void*)&kNGAParallaxMotio
     return val.doubleValue;
 }
 
-#pragma mark -
+#pragma mark - EffectGroupKey access methods
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
 
 -(UIMotionEffectGroup*)nga_parallaxMotionEffectGroup
 {
+    if (!objc_getAssociatedObject(self, kNGAParallaxMotionEffectGroupKey))
+    {
+        UIMotionEffectGroup * parallaxGroup = [[UIMotionEffectGroup alloc] init];
+        [self nga_setParallaxMotionEffectGroup:parallaxGroup];
+        return parallaxGroup;
+    }
     return objc_getAssociatedObject(self, kNGAParallaxMotionEffectGroupKey);
 }
 


### PR DESCRIPTION
Hello, this is a great category, thanks for releasing :smile_cat: 

I thought it would be cleaner if the getter function was responsible for ensuring a valid UIMotionEffectGroup is returned. Open to feedback if this pull req doesn't meet your standards. 
