### PR TITLE
removing strong references from project example

### DIFF
--- a/Examples/NGAParallaxMotion Demo/NGAViewController.m
+++ b/Examples/NGAParallaxMotion Demo/NGAViewController.m
@@ -11,9 +11,9 @@
 
 @interface NGAViewController ()
 
-@property (strong, nonatomic) IBOutlet UISwitch *parallaxSwitch;
-@property (strong, nonatomic) IBOutlet UISegmentedControl *parallaxConstraintControl;
-@property (strong, nonatomic) IBOutlet UILabel *midLabel;
+@property (weak, nonatomic) IBOutlet UISwitch *parallaxSwitch;
+@property (weak, nonatomic) IBOutlet UISegmentedControl *parallaxConstraintControl;
+@property (weak, nonatomic) IBOutlet UILabel *midLabel;
 @property (strong, nonatomic) NSArray * labels;
 @end
 


### PR DESCRIPTION
strong references from a view to its subviews causes a retain cycle
@see https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmPractical.html
@see http://www.cocoawithlove.com/2009/07/rules-to-avoid-retain-cycles.html
